### PR TITLE
niv home-manager: update 1d2f0b3d -> 6bf057fc

### DIFF
--- a/.github/workflows/niv-update.yml
+++ b/.github/workflows/niv-update.yml
@@ -1,0 +1,53 @@
+name: Automated niv-managed dependency updates
+
+on:
+  workflow_dispatch: {}          # manual trigger
+  schedule:
+    - cron: '0 4 * * *'          # every day 04:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  niv-updater:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: cachix/install-nix-action@v31.3.0
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@v16
+        with:
+          name: siraben
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: niv update
+        run: |
+          nix run nixpkgs#niv update
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet nix/sources.json; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=true"  >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Home-Manager config
+        if: steps.changes.outputs.changed == 'true'
+        run: nix-shell -p home-manager --run \
+             "home-manager build -f home-manager/.config/nixpkgs/home.nix"
+
+      - name: niv-updater-action
+        if: steps.changes.outputs.changed == 'true' && success()
+        uses: knl/niv-updater-action@v15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          keep_updating: true

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d2f0b3d4be0fed93c31d21603f988c68d5a4d16",
-        "sha256": "0w6ydyqb950mdvyb4zygzbcdnpmmmkllmn1flp3xa7s463zg65vb",
+        "rev": "6bf057fc8326e83bda05a669fc08d106547679fb",
+        "sha256": "15frrybphs875s3s95al5jmm4bh5y56126brwgsp6xafndkfd1p0",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6bf057fc8326e83bda05a669fc08d106547679fb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1d2f0b3d...6bf057fc](https://github.com/nix-community/home-manager/compare/1d2f0b3d4be0fed93c31d21603f988c68d5a4d16...6bf057fc8326e83bda05a669fc08d106547679fb)

* [`29fce40e`](https://github.com/nix-community/home-manager/commit/29fce40e1391477b66ef3a24ea7867f0bc5b52a1) espanso: add crossplatform support
* [`6ed700bf`](https://github.com/nix-community/home-manager/commit/6ed700bfe4fe6b66a9121365056f63041b85ab3d) espanso: fix test
* [`9c3b33c2`](https://github.com/nix-community/home-manager/commit/9c3b33c2a7531cd4cbdcc5690cc0f69e93e60aa3) espanso: add wayland test
* [`0fbd8207`](https://github.com/nix-community/home-manager/commit/0fbd8207e913b2d1660a7662f9ae80e5e639de65) news: forward args to file news entries
* [`adb3fbc5`](https://github.com/nix-community/home-manager/commit/adb3fbc58455de60ad4131c6e59d596ea2bb105f) neomutt: use correct neomutt in config file ([nix-community/home-manager⁠#6915](https://togithub.com/nix-community/home-manager/issues/6915))
* [`2a264c17`](https://github.com/nix-community/home-manager/commit/2a264c17d5fb3673eeec891ea4a82027a41addc3) zsh: add type to zprof.enable option ([nix-community/home-manager⁠#6916](https://togithub.com/nix-community/home-manager/issues/6916))
* [`edaeeda2`](https://github.com/nix-community/home-manager/commit/edaeeda26429aa3d25b9119f358075813bd9d4ba) eza: default disable nushell integration again
* [`7b2aae3f`](https://github.com/nix-community/home-manager/commit/7b2aae3fb39928aecc5e41c10a9c87c4881614d5) eza: add tests
* [`9c46dc88`](https://github.com/nix-community/home-manager/commit/9c46dc881c2afcb50ac9ae9f1c36b2a4ebba3c8a) mkFirefoxModule: support wrapped darwin derivations ([nix-community/home-manager⁠#6913](https://togithub.com/nix-community/home-manager/issues/6913))
* [`cf351071`](https://github.com/nix-community/home-manager/commit/cf351071fb4aac4add29ed6a88cc75a8c2865b5e) lsd: enableAliases -> enableShellIntegration
* [`77f849c1`](https://github.com/nix-community/home-manager/commit/77f849c11458ee00dcf722ca267edefd3f51743e) lsd: refactor module
* [`be7cf170`](https://github.com/nix-community/home-manager/commit/be7cf1709b469a2a2c62169172a167d1fed3509f) lsd: add package option
* [`69c60b03`](https://github.com/nix-community/home-manager/commit/69c60b035e6bb51a4c5607f184bf64312c294139) kickoff: add module ([nix-community/home-manager⁠#6918](https://togithub.com/nix-community/home-manager/issues/6918))
* [`6f974faa`](https://github.com/nix-community/home-manager/commit/6f974faa1962e2ee081635124ab96a1bfacb2f25) gh: add `hosts` option ([nix-community/home-manager⁠#6925](https://togithub.com/nix-community/home-manager/issues/6925))
* [`c54a8ab0`](https://github.com/nix-community/home-manager/commit/c54a8ab0d2ea7486eadb14f1dc498817ff164f59) rofi: remove thiagokokada from maintainers ([nix-community/home-manager⁠#6928](https://togithub.com/nix-community/home-manager/issues/6928))
* [`d0d9d0a1`](https://github.com/nix-community/home-manager/commit/d0d9d0a1454d5a0200693570618084d80a8b336c) mpvpaper: add module ([nix-community/home-manager⁠#6926](https://togithub.com/nix-community/home-manager/issues/6926))
* [`4d2baba7`](https://github.com/nix-community/home-manager/commit/4d2baba75e9de32f6f552fe02797f46cd6f46bd9) espanso: fix alias in news ([nix-community/home-manager⁠#6931](https://togithub.com/nix-community/home-manager/issues/6931))
* [`c803a389`](https://github.com/nix-community/home-manager/commit/c803a38927b9b3b15dc83aecae27af3172be5ee2) nh: add path option for flake ([nix-community/home-manager⁠#6898](https://togithub.com/nix-community/home-manager/issues/6898))
* [`1ad12323`](https://github.com/nix-community/home-manager/commit/1ad123239957d40e11ef66c203d0a7e272eb48aa) rclone: make secret injection non-interactive ([nix-community/home-manager⁠#6919](https://togithub.com/nix-community/home-manager/issues/6919))
* [`a4c3ce44`](https://github.com/nix-community/home-manager/commit/a4c3ce44fcd65849751caab203c2076b092e7069) gpg-agent: pinentryPackage -> pinentry.package and add pinentry.program`
* [`e9c80e27`](https://github.com/nix-community/home-manager/commit/e9c80e277b572f642835afbf0d793b72cf49f551) tests/gpg-agent: add pinentry-program test
* [`9389f373`](https://github.com/nix-community/home-manager/commit/9389f373bee64cc8459253e0ab00635b05c0bcb6) pls: enableAliases -> enableShellIntegration ([nix-community/home-manager⁠#6932](https://togithub.com/nix-community/home-manager/issues/6932))
* [`84d26211`](https://github.com/nix-community/home-manager/commit/84d262115e10ad321ef01cd85903d0f5c3ec113f) nixos,darwin: add osClass (_class) as a specialArg ([nix-community/home-manager⁠#6906](https://togithub.com/nix-community/home-manager/issues/6906))
* [`ca39b348`](https://github.com/nix-community/home-manager/commit/ca39b348299bb772a7cca2271cef9b91845a390a) carapace: fix nushell PATH env var ([nix-community/home-manager⁠#6936](https://togithub.com/nix-community/home-manager/issues/6936))
* [`d2b3e6c8`](https://github.com/nix-community/home-manager/commit/d2b3e6c83d457aa0e7f9344c61c3fed32bad0f7e) flake.lock: Update ([nix-community/home-manager⁠#6937](https://togithub.com/nix-community/home-manager/issues/6937))
* [`c9c2c1a1`](https://github.com/nix-community/home-manager/commit/c9c2c1a14e8d6292857272a0a56a4213664ec8fa) kime: fix systemd service ([nix-community/home-manager⁠#6911](https://togithub.com/nix-community/home-manager/issues/6911))
* [`272eb00d`](https://github.com/nix-community/home-manager/commit/272eb00d1396bd86e77ebefd1abc47dfcab837b3) fcitx5: ensure config doesn't get overwritten ([nix-community/home-manager⁠#6940](https://togithub.com/nix-community/home-manager/issues/6940))
* [`7f301a4d`](https://github.com/nix-community/home-manager/commit/7f301a4d968f3b846efde5a43455d959b69a348f) restic: fix certain integration tests
* [`5f217e5a`](https://github.com/nix-community/home-manager/commit/5f217e5a319f6c186283b530f8c975e66c028433) restic: change service type from `simple` to `oneshot`
* [`81431b6d`](https://github.com/nix-community/home-manager/commit/81431b6d6fa756db641109461fc943ba23b550b7) gpg-agent: fix typo ([nix-community/home-manager⁠#6950](https://togithub.com/nix-community/home-manager/issues/6950))
* [`4e7ee4d0`](https://github.com/nix-community/home-manager/commit/4e7ee4d02cc323fc338ff978ca4a2b72e08f5d8d) home-manager: new formatting of generated configuration
* [`015f1913`](https://github.com/nix-community/home-manager/commit/015f1913109d44c36e683b55f0e47e283b383caa) ci: remove GitLab rycee/nur-expression update
* [`1298a341`](https://github.com/nix-community/home-manager/commit/1298a3418be1a875e9ae6643770b0939814cd441) ci: remove release-24.05 from dependabot setup
* [`361ab448`](https://github.com/nix-community/home-manager/commit/361ab4484e7b91a7b6bdedc6784e2a44d20a3dce) home-environment: add `home.extraDependencies`
* [`f045bd46`](https://github.com/nix-community/home-manager/commit/f045bd46b73c3b0ed4e46cdb6036b3d5823d7dee) fish: keep all fish-completions packages around
* [`669e813c`](https://github.com/nix-community/home-manager/commit/669e813c752696c66ad7e1cd34b65ee4315058d9) element-desktop: add module ([nix-community/home-manager⁠#6935](https://togithub.com/nix-community/home-manager/issues/6935))
* [`c5cad190`](https://github.com/nix-community/home-manager/commit/c5cad190ba252eb94540ee06955a53c7807963f8) zsh: update doc to show how to add `initContent` at multiple location. ([nix-community/home-manager⁠#6945](https://togithub.com/nix-community/home-manager/issues/6945))
* [`f15be4fe`](https://github.com/nix-community/home-manager/commit/f15be4feb6e98fc2c52d4f8088400619381fd171) clipcat: add module ([nix-community/home-manager⁠#6946](https://togithub.com/nix-community/home-manager/issues/6946))
* [`2eabb26d`](https://github.com/nix-community/home-manager/commit/2eabb26d0859c7710a2aa76c3b0ff4149f41b04a) restic: allow the convenience script to source environmentFile ([nix-community/home-manager⁠#6947](https://togithub.com/nix-community/home-manager/issues/6947))
* [`355a6b93`](https://github.com/nix-community/home-manager/commit/355a6b937d07a95cb0b753ef513bcaad09128dea) nushell: throw instead of abort ([nix-community/home-manager⁠#6870](https://togithub.com/nix-community/home-manager/issues/6870))
* [`d6b0c054`](https://github.com/nix-community/home-manager/commit/d6b0c054571a444acd2755b038bb7df5eb7954a7) visidata: add module ([nix-community/home-manager⁠#6956](https://togithub.com/nix-community/home-manager/issues/6956))
* [`1e8c62c6`](https://github.com/nix-community/home-manager/commit/1e8c62c651242fc685b10efc4a48ab777635fb7f) gpg-agent: avoid console output when using ssh
* [`123297c5`](https://github.com/nix-community/home-manager/commit/123297c57e77c692fae7e860e701823367afbec4) onagre: add module ([nix-community/home-manager⁠#6958](https://togithub.com/nix-community/home-manager/issues/6958))
* [`c0962eee`](https://github.com/nix-community/home-manager/commit/c0962eeeabfb8127713f859ec8a5f0e86dead0f2) thunderbird: fix accounts being removed ([nix-community/home-manager⁠#6959](https://togithub.com/nix-community/home-manager/issues/6959))
* [`929f8ee8`](https://github.com/nix-community/home-manager/commit/929f8ee8362aec0a2bcbcbbd485e86e701496a73) thunderbird: deprecate darwinSetupWarning option ([nix-community/home-manager⁠#6531](https://togithub.com/nix-community/home-manager/issues/6531))
* [`75268f62`](https://github.com/nix-community/home-manager/commit/75268f62525920c4936404a056f37b91e299c97e) tests: enable all firefox tests on darwin (plus derivations) ([nix-community/home-manager⁠#6960](https://togithub.com/nix-community/home-manager/issues/6960))
* [`94f4c666`](https://github.com/nix-community/home-manager/commit/94f4c66660faa994676176d1d3d94618a796c39e) tests/darwinScrublist: add more packages ([nix-community/home-manager⁠#6965](https://togithub.com/nix-community/home-manager/issues/6965))
* [`d1bbab6b`](https://github.com/nix-community/home-manager/commit/d1bbab6b04d865d759505f33a5c6743bbb544074) mako: refactor ([nix-community/home-manager⁠#6948](https://togithub.com/nix-community/home-manager/issues/6948))
* [`64f7d5e6`](https://github.com/nix-community/home-manager/commit/64f7d5e6b94e2e66e3b344fe8e002c9da97a57b1) wofi: allow path to style.css ([nix-community/home-manager⁠#6966](https://togithub.com/nix-community/home-manager/issues/6966))
* [`621986fe`](https://github.com/nix-community/home-manager/commit/621986fed37c5d0cb8df010ed8369694dc47c09b) i3bar-river: add module ([nix-community/home-manager⁠#6967](https://togithub.com/nix-community/home-manager/issues/6967))
* [`3a185176`](https://github.com/nix-community/home-manager/commit/3a185176e48206026b8c1e6dc3f3a37ffff4b9f7) flake.lock: Update ([nix-community/home-manager⁠#6969](https://togithub.com/nix-community/home-manager/issues/6969))
* [`8167af65`](https://github.com/nix-community/home-manager/commit/8167af657c0aa58fbe1fabfe7cce0520380c1bb3) mako: fix criterias typo ([nix-community/home-manager⁠#6968](https://togithub.com/nix-community/home-manager/issues/6968))
* [`1a1793f6`](https://github.com/nix-community/home-manager/commit/1a1793f6d940d22c6e49753548c5b6cb7dc5545d) ghostty: fix config syntax file location on darwin ([nix-community/home-manager⁠#6970](https://togithub.com/nix-community/home-manager/issues/6970))
* [`5f1f4725`](https://github.com/nix-community/home-manager/commit/5f1f472565ee59b5001ae5022bbb1a9a64239f91) mako: use ini atom type ([nix-community/home-manager⁠#6977](https://togithub.com/nix-community/home-manager/issues/6977))
* [`8a318641`](https://github.com/nix-community/home-manager/commit/8a318641ac13d3bc0a53651feaee9560f9b2d89a) sway-easyfocus: add module ([nix-community/home-manager⁠#6976](https://togithub.com/nix-community/home-manager/issues/6976))
* [`60964ff8`](https://github.com/nix-community/home-manager/commit/60964ff845ec5965cde978377f3f73bcef84abe5) mako: fix example config ([nix-community/home-manager⁠#6987](https://togithub.com/nix-community/home-manager/issues/6987))
* [`35535345`](https://github.com/nix-community/home-manager/commit/35535345be0be7dbae2e9b787c6cf790f8c893d5) television: add shell integrations ([nix-community/home-manager⁠#6983](https://togithub.com/nix-community/home-manager/issues/6983))
* [`e121442b`](https://github.com/nix-community/home-manager/commit/e121442b6583fdbfd968cca6fb7def58af0b6288) lib/strings: add toSnakeCase
* [`9cebc4cb`](https://github.com/nix-community/home-manager/commit/9cebc4cb8af0d4f71acadbb5f53bee1e406cec03) lib/strings: add toKebabCase
* [`94d32062`](https://github.com/nix-community/home-manager/commit/94d32062ca42d8149cd77d2b3e3ec5c8c4103084) lib/strings: add toCaseWithSeparator
* [`327885ce`](https://github.com/nix-community/home-manager/commit/327885ceae1aecc9b966e9370eb4043d2c169b0c) lib/deprecations: add mkSettingsRenamedOptionModules with transform parameter
* [`f78a171f`](https://github.com/nix-community/home-manager/commit/f78a171fe4e6a6e0ae5c33c5be8abe72e8a43eb3) mako: use toKebabCase for option transformation
* [`ba454389`](https://github.com/nix-community/home-manager/commit/ba45438996c3bc6c245af9833904c12836923b8d) tests/darwinScrublist: add newsboat
* [`76274a21`](https://github.com/nix-community/home-manager/commit/76274a2130db36a6754f0bf262daac63f2afbd1e) tests/man: index.bt -> index.db
* [`5da6eafc`](https://github.com/nix-community/home-manager/commit/5da6eafceb2ea15b39de54d853cc224409e4c1a9) treewide: remove unused code ([nix-community/home-manager⁠#6985](https://togithub.com/nix-community/home-manager/issues/6985))
* [`1d5fb9da`](https://github.com/nix-community/home-manager/commit/1d5fb9da1061e30012ee68675a489ac5780c1877) flake.lock: Update ([nix-community/home-manager⁠#6992](https://togithub.com/nix-community/home-manager/issues/6992))
* [`f3384e68`](https://github.com/nix-community/home-manager/commit/f3384e688da328fcec78c6a437566b40fd6f8a18) tmpfiles: also remove files that need to be removed during activation ([nix-community/home-manager⁠#6980](https://togithub.com/nix-community/home-manager/issues/6980))
* [`ae442685`](https://github.com/nix-community/home-manager/commit/ae442685297517b5fcdd85787d95c3927e4aabf5) prezto: Remove unnecessary import-from-derivation
* [`708074ae`](https://github.com/nix-community/home-manager/commit/708074ae6db9e0468e4f48477f856e8c2d059795) treewide: Prevent IFD by default
* [`a8e2d08f`](https://github.com/nix-community/home-manager/commit/a8e2d08ffdc68123316b57cf2ad51244c7eca335) alot: allow commas in maildir path ([nix-community/home-manager⁠#6989](https://togithub.com/nix-community/home-manager/issues/6989))
* [`ec71b516`](https://github.com/nix-community/home-manager/commit/ec71b5162848e6369bdf2be8d2f1dd41cded88e8) sbt: Scoping credentials to ThisBuild ([nix-community/home-manager⁠#6026](https://togithub.com/nix-community/home-manager/issues/6026))
* [`50894120`](https://github.com/nix-community/home-manager/commit/50894120e8ac792a5d3046d23e4e4c4ef32cf09c) modules/modules.nix: drop duplicate entry ([nix-community/home-manager⁠#7000](https://togithub.com/nix-community/home-manager/issues/7000))
* [`2ede089d`](https://github.com/nix-community/home-manager/commit/2ede089d11b68d7abfcb022c60cf71249504c3b0) git: configure patdiff through [patdiff] git section ([nix-community/home-manager⁠#6978](https://togithub.com/nix-community/home-manager/issues/6978))
* [`cea975d4`](https://github.com/nix-community/home-manager/commit/cea975d46d08293eae3ad0d9f16207f1ce2dfc81) rofi: modes option ([nix-community/home-manager⁠#6115](https://togithub.com/nix-community/home-manager/issues/6115))
* [`c84396bd`](https://github.com/nix-community/home-manager/commit/c84396bda0371cb42147c82ad051bebf8a158bd5) rofi: modes optional ([nix-community/home-manager⁠#7003](https://togithub.com/nix-community/home-manager/issues/7003))
* [`3c59c513`](https://github.com/nix-community/home-manager/commit/3c59c5132b64e885faca381e713b579dcbddba75) wayprompt: init module ([nix-community/home-manager⁠#7002](https://togithub.com/nix-community/home-manager/issues/7002))
* [`a5159823`](https://github.com/nix-community/home-manager/commit/a51598236f23c89e59ee77eb8e0614358b0e896c) lutris: add module ([nix-community/home-manager⁠#6964](https://togithub.com/nix-community/home-manager/issues/6964))
* [`5d428b68`](https://github.com/nix-community/home-manager/commit/5d428b68dd56b98f023f5360002e3fe4b66a2b63) docs: update filename of generated HTML manual ([nix-community/home-manager⁠#7010](https://togithub.com/nix-community/home-manager/issues/7010))
* [`8d2ee399`](https://github.com/nix-community/home-manager/commit/8d2ee39915119dead6b794f7d2b63d6a1554941d) waveterm: add module ([nix-community/home-manager⁠#7004](https://togithub.com/nix-community/home-manager/issues/7004))
* [`ce1ba0e9`](https://github.com/nix-community/home-manager/commit/ce1ba0e9f34df84e1e1d7c8ab3d4c948e81f0e20) neovide: fix error when no settings are declared ([nix-community/home-manager⁠#7005](https://togithub.com/nix-community/home-manager/issues/7005))
* [`9e10d73c`](https://github.com/nix-community/home-manager/commit/9e10d73cea313708e9f9b98114963fbaac6ec99b) onlyoffice: use pkgs.formats and use mkIf in config file generation ([nix-community/home-manager⁠#7006](https://togithub.com/nix-community/home-manager/issues/7006))
* [`8f723d61`](https://github.com/nix-community/home-manager/commit/8f723d613588e4a55e8838197741727e4dea4944) lutris: fix runners not working due to wrong config name ([nix-community/home-manager⁠#7008](https://togithub.com/nix-community/home-manager/issues/7008))
* [`cbd8e8e9`](https://github.com/nix-community/home-manager/commit/cbd8e8e9a040db35d6a74a8f8903a32a2e47b8c5) PR_TEMPLATE: update example for module maintainer ([nix-community/home-manager⁠#7011](https://togithub.com/nix-community/home-manager/issues/7011))
* [`3be7c80a`](https://github.com/nix-community/home-manager/commit/3be7c80a11b3b1c3c14d0061dfaa44f1c96673ff) wayprompt: add news entry for linux ([nix-community/home-manager⁠#7009](https://togithub.com/nix-community/home-manager/issues/7009))
* [`f2b5bf55`](https://github.com/nix-community/home-manager/commit/f2b5bf55aa439a6c517adfcb9715a5a952020c5f) direnv: update nushell env conversion logic ([nix-community/home-manager⁠#6999](https://togithub.com/nix-community/home-manager/issues/6999))
* [`e9bd9568`](https://github.com/nix-community/home-manager/commit/e9bd9568db6b627155664090ea39a1b6ece0af47) jujutsu: store configuration in $XDG_CONFIG_HOME for all platforms ([nix-community/home-manager⁠#6994](https://togithub.com/nix-community/home-manager/issues/6994))
* [`b706037a`](https://github.com/nix-community/home-manager/commit/b706037a60acc727f1b5c037e84dc61a35ef1db1) distrobox: make systemd unit optional ([nix-community/home-manager⁠#7007](https://togithub.com/nix-community/home-manager/issues/7007))
* [`e95a7c5b`](https://github.com/nix-community/home-manager/commit/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c) Revert "direnv: update nushell env conversion logic ([nix-community/home-manager⁠#6999](https://togithub.com/nix-community/home-manager/issues/6999))" ([nix-community/home-manager⁠#7014](https://togithub.com/nix-community/home-manager/issues/7014))
* [`c4bd004d`](https://github.com/nix-community/home-manager/commit/c4bd004d9d8981837d958264b809f7edc93d9957) flake.nix: expose create-news-entry as a package
* [`6fd639db`](https://github.com/nix-community/home-manager/commit/6fd639dbe5183850b6c4a7fb47ae04c4808cb891) docs: update news.md to highlight create-news-entry command
* [`12e67385`](https://github.com/nix-community/home-manager/commit/12e67385964d9c9304daa81d0ad5ba3b01fdd35e) docs: remove recommendation to wait for maintainers for news
* [`b96c332d`](https://github.com/nix-community/home-manager/commit/b96c332dce9a1974ee046a4dcd5860a5f41009f5) maintainers: add lowlevl
* [`4f442217`](https://github.com/nix-community/home-manager/commit/4f44221724ce074404fb0e569acdd6c456ed22d2) services.autorandr: add lowlevl to maintainers
* [`555f88ad`](https://github.com/nix-community/home-manager/commit/555f88ad3452f1d2ce1560e7209b0b6af0c6033b) services.autorandr: add package option
* [`1875b5a1`](https://github.com/nix-community/home-manager/commit/1875b5a1606a897d9285d80600c7ab566911c7bc) services.autorandr: improve configurability
* [`13289f06`](https://github.com/nix-community/home-manager/commit/13289f06429700f3ecf8f5109ed8831839f09145) services.autorandr: improve systemd unit description
* [`9ef92f1c`](https://github.com/nix-community/home-manager/commit/9ef92f1c6b77944198fd368ec805ced842352a1d) waveterm: fix markdown in description
* [`de496c9c`](https://github.com/nix-community/home-manager/commit/de496c9ccb705ed76c1f23c2cad13e8970c37f0b) television: add support for channels ([nix-community/home-manager⁠#7026](https://togithub.com/nix-community/home-manager/issues/7026))
* [`6991569c`](https://github.com/nix-community/home-manager/commit/6991569cb7cdde9891f52b43abe9916779df45b0) flake.lock: Update
* [`ff915842`](https://github.com/nix-community/home-manager/commit/ff915842e4a2e63c4c8c5c08c6870b9d5b3c3ee9) Translate using Weblate (Catalan)
* [`5daf23a3`](https://github.com/nix-community/home-manager/commit/5daf23a38f53119803d1e329bf2eaa101563999c) zellij: add themes option ([nix-community/home-manager⁠#7031](https://togithub.com/nix-community/home-manager/issues/7031))
* [`563e1b6c`](https://github.com/nix-community/home-manager/commit/563e1b6cb08256aa883526f5f3deb6970f390e58) maintainers: add Aehmlo
* [`ecb21624`](https://github.com/nix-community/home-manager/commit/ecb216242293f8a31c5426b40190700e5b3686fd) numbat: add module
* [`910292fe`](https://github.com/nix-community/home-manager/commit/910292fe342071f83d6906c7ca24864eba28676a) halloy: add module ([nix-community/home-manager⁠#7034](https://togithub.com/nix-community/home-manager/issues/7034))
* [`a48fecda`](https://github.com/nix-community/home-manager/commit/a48fecda099e9324134f6dd88fe7e38f58d2d9d2) files: add home.file.<name>.ignorelinks
* [`7a3f3e55`](https://github.com/nix-community/home-manager/commit/7a3f3e550737c3ed43f6abf33a560cb58537d21f) misc: fix mozilla native messaging hosts
* [`c74665ab`](https://github.com/nix-community/home-manager/commit/c74665abd6e4e37d3140e68885bc49a994ffa53c) bacon: add prefs location to settings decription ([nix-community/home-manager⁠#7030](https://togithub.com/nix-community/home-manager/issues/7030))
* [`4a7311c2`](https://github.com/nix-community/home-manager/commit/4a7311c2353a1ae1292500e25b0e18866dd115aa) misc: add news entries for May modules
* [`0083d901`](https://github.com/nix-community/home-manager/commit/0083d901a33696bf8d29966775bc420e302fb7ea) misc: add news entries for April modules
* [`fb061f55`](https://github.com/nix-community/home-manager/commit/fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52) misc: add news entries for March modules
* [`58795314`](https://github.com/nix-community/home-manager/commit/587953146298b13e897b827181967ff2298fb63c) wayprompt: tweak example ([nix-community/home-manager⁠#7040](https://togithub.com/nix-community/home-manager/issues/7040))
* [`0b24658e`](https://github.com/nix-community/home-manager/commit/0b24658ec09908e5a6515cacc54f29d589c8423b) halloy: add themes option ([nix-community/home-manager⁠#7043](https://togithub.com/nix-community/home-manager/issues/7043))
* [`f0a7db5e`](https://github.com/nix-community/home-manager/commit/f0a7db5ec1d369721e770a45e4d19f8e48186a69) direnv: update nushell env conversion logic ([nix-community/home-manager⁠#7015](https://togithub.com/nix-community/home-manager/issues/7015))
* [`bc13c13e`](https://github.com/nix-community/home-manager/commit/bc13c13ed7f7545a9f34010fa8c3febd1a92c58b) news: reorganize news into YYYY/MM directory structure
* [`628d8cfa`](https://github.com/nix-community/home-manager/commit/628d8cfa5441eabe07fbb24861df1236a8e6dde5) news: migrate news entries to YYYY/MM directory structure
* [`665c49e0`](https://github.com/nix-community/home-manager/commit/665c49e0c2982d94f30a9826712850a59f70eeb4) gnome-terminal: add package option ([nix-community/home-manager⁠#7048](https://togithub.com/nix-community/home-manager/issues/7048))
* [`012cc9e1`](https://github.com/nix-community/home-manager/commit/012cc9e1666b8ce0d6f677b902651f6858dfbe45) halloy: add note about server being required ([nix-community/home-manager⁠#7047](https://togithub.com/nix-community/home-manager/issues/7047))
* [`535a541b`](https://github.com/nix-community/home-manager/commit/535a541b429c1e89f0955c160df1d6d2bfeaf802) halloy: fix themes example ([nix-community/home-manager⁠#7046](https://togithub.com/nix-community/home-manager/issues/7046))
* [`dc589997`](https://github.com/nix-community/home-manager/commit/dc5899978f8fa5d72424d5242784fb7e84e8573e) services/mako: refactor settings to support INI sections
* [`0be2c246`](https://github.com/nix-community/home-manager/commit/0be2c246e37a5b6e851111bfcf07ab37194e4954) mako: deprecate criteria option
* [`78ad8e3c`](https://github.com/nix-community/home-manager/commit/78ad8e3c31cc5239674dfd7ca6159e5ca14da0e8) tests/mako: add a deprecation test
* [`df556f2a`](https://github.com/nix-community/home-manager/commit/df556f2a17b7b94148d0275c1a57fed20e62ad18) tests/mako: add a original deprecation test
* [`8d832ddf`](https://github.com/nix-community/home-manager/commit/8d832ddfda9facf538f3dda9b6985fb0234f151c) foliate: init ([nix-community/home-manager⁠#7049](https://togithub.com/nix-community/home-manager/issues/7049))
* [`b44c39cf`](https://github.com/nix-community/home-manager/commit/b44c39cf4618ccf58df2b68827ca95a3fecf0655) foliate: fix theme settings example ([nix-community/home-manager⁠#7053](https://togithub.com/nix-community/home-manager/issues/7053))
* [`5f36563a`](https://github.com/nix-community/home-manager/commit/5f36563a5cae05bcfbaa5e08a69d2e8d94242f61) zsh: consider zsh.{profile,login,logout,env}Extra in prezto
* [`7c1cefb9`](https://github.com/nix-community/home-manager/commit/7c1cefb98369cc85440642fdccc1c1394ca6dd2c) zsh: avoid IFD while sourcing prezto
* [`6bf057fc`](https://github.com/nix-community/home-manager/commit/6bf057fc8326e83bda05a669fc08d106547679fb) zsh: do not duplicate zsh.{profile,login,logout,env}Extra in prezto ([nix-community/home-manager⁠#7061](https://togithub.com/nix-community/home-manager/issues/7061))
