### PR TITLE
home-manager: add agent-deck with declarative config (headless)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,6 +45,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -171,7 +187,30 @@
         "home-manager": "home-manager_2",
         "mac-app-util": "mac-app-util",
         "mosh-unicode": "mosh-unicode",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "siraben-overlay": "siraben-overlay"
+      }
+    },
+    "siraben-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1777262194,
+        "narHash": "sha256-DYVkQq/EatYJ0uhA5SpRD83+WdBeJ8iqMJaC892OyOU=",
+        "owner": "siraben",
+        "repo": "overlay",
+        "rev": "2fe2dc826f3de7cfbe405c822bdb2b792d7a9f26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "siraben",
+        "repo": "overlay",
+        "type": "github"
       }
     },
     "systems": {
@@ -201,6 +240,39 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-darwin",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,10 @@
       url = "github:siraben/mosh/unicode";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    siraben-overlay = {
+      url = "github:siraben/overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { self, nixpkgs, home-manager, mac-app-util, ... /* Capture all inputs */ }@allInputs:

--- a/home-manager/.config/nixpkgs/base.nix
+++ b/home-manager/.config/nixpkgs/base.nix
@@ -14,6 +14,7 @@ let
   pkgsOptions = {
     overlays = [
       (import ./overlay.nix { inherit inputs; })
+      inputs.siraben-overlay.overlays.default
     ];
     config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) unfreePackages;
   };
@@ -43,6 +44,17 @@ lib.recursiveUpdate (rec {
   home.language = {
     ctype = "en_US.UTF-8";
     base = "en_US.UTF-8";
+  };
+
+  home.file = lib.optionalAttrs (profile == "headless") {
+    ".agent-deck/config.toml".source =
+      (pkgs.formats.toml { }).generate "agent-deck-config" {
+        default_tool = "claude";
+        theme = "dark";
+        worktree.branch_prefix = "siraben/";
+        claude.dangerous_mode = true;
+        feedback.disabled = true;
+      };
   };
 
   programs = import ./programs.nix { inherit lib pkgs isDarwin isLinux profile; };

--- a/home-manager/.config/nixpkgs/packages.nix
+++ b/home-manager/.config/nixpkgs/packages.nix
@@ -2,8 +2,10 @@
 let
   isMinimal = profile == "minimal";
   isFull = profile == "full";
+  isHeadless = profile == "headless";
   whenNotMinimal = lib.optionals (!isMinimal);
   whenFull = lib.optionals isFull;
+  whenHeadless = lib.optionals isHeadless;
   my-emacs = with pkgs; emacs.pkgs.withPackages (p: [ p.vterm ]);
   wayland-packages = whenFull (with pkgs; [
     firefox
@@ -50,7 +52,9 @@ let
     gh
     ranger
     croc
-  ] ++ (whenNotMinimal ([
+  ] ++ (whenHeadless [
+    agent-deck
+  ]) ++ (whenNotMinimal ([
     # CLI tools (headless + full)
     claude-code
     codex


### PR DESCRIPTION
## Summary
- Pull `agent-deck` from the `siraben/overlay` flake input and install it on the **headless** profile only.
- Generate `~/.agent-deck/config.toml` declaratively from Nix via `pkgs.formats.toml`.
- Set `worktree.branch_prefix = "siraben/"` (replaces the `feature/` default for auto-named worktree branches).

## Why
Until now the agent-deck binary was launched ad-hoc via `nix run github:siraben/overlay#agent-deck`, and its config lived as a regular file at `~/.agent-deck/config.toml` that drifted between hosts. Putting it under home-manager makes it reproducible across the headless boxes (beelink and arm servers) and codifies the branch prefix preference.

## Notes / caveats
- The TOML file becomes a Nix-store symlink, so the in-TUI `S` Settings panel can no longer write to it. Edit `agent-deck.nix` and re-switch instead.
- On first switch, home-manager will balk at the existing `~/.agent-deck/config.toml`. Either `rm` it first or run `home-manager switch -b backup`.
- `home-manager switch` will kill the active tmux server (version mismatch between in-PATH tmux and the running server). Run from a tmux you're willing to lose, or from a plain shell.
- Only headless gets it for now — `full` (darwin) is unchanged. Easy to flip the gate to `whenNotMinimal` if you want it on darwin too.

## Test plan
- [x] `nix flake metadata` resolves with `siraben-overlay` input present
- [x] `nix eval .#homeConfigurations."siraben@x86_64-linux-headless".config.home.file.".agent-deck/config.toml".source` builds the TOML
- [x] Generated TOML contains `branch_prefix = 'siraben/'` under `[worktree]`
- [x] `agent-deck` is in `home.packages` for headless, absent for full
- [ ] `home-manager switch --flake .#siraben@x86_64-linux-headless` succeeds on beelink
- [ ] `agent-deck` launches and "New session with worktree" produces a `siraben/<name>` branch