### PR TITLE
emacs: gate optional tooling by host capabilities

### DIFF
--- a/emacs/.emacs.d/init.el
+++ b/emacs/.emacs.d/init.el
@@ -77,6 +77,7 @@
 
 ;; Load configuration modules
 (require 'siraben-core)
+(require 'siraben-capabilities)
 (require 'siraben-packages)
 (require 'siraben-ui)
 (require 'siraben-fonts)

--- a/emacs/.emacs.d/modules/siraben-c.el
+++ b/emacs/.emacs.d/modules/siraben-c.el
@@ -53,17 +53,25 @@
     ;; ("NULL"   . ?∅)
     ))
 
+(require 'siraben-capabilities)
+
+(defun siraben--maybe-enable-clang-format ()
+  "Enable `clang-format+-mode' iff a clang-format binary is installed."
+  (when (and (fboundp 'clang-format+-mode)
+             (siraben-have-p "clang-format"))
+    (clang-format+-mode 1)))
+
 (add-hook 'c-mode-hook (lambda ()
                          (electric-pair-local-mode t)
                          (electric-indent-mode t)
-                         (clang-format+-mode t)
+                         (siraben--maybe-enable-clang-format)
                          (setq-local prettify-symbols-alist c-prettify-symbols-alist)
                          (prettify-symbols-mode 1)
                          ;; (lsp)
                          ))
 
 (add-hook 'c++-mode-hook (lambda ()
-                           (clang-format+-mode t)
+                           (siraben--maybe-enable-clang-format)
                            (electric-pair-local-mode t)
                            ;; (lsp)
                            ))

--- a/emacs/.emacs.d/modules/siraben-capabilities.el
+++ b/emacs/.emacs.d/modules/siraben-capabilities.el
@@ -1,0 +1,150 @@
+;;; siraben-capabilities.el --- Capability detection for external tools
+
+;;; License:
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This module centralises detection of external programs (compilers,
+;; language servers, formatters, etc.) so that the rest of the config
+;; can be capability-driven: features auto-enable when their backing
+;; binary is installed and silently skip otherwise.
+;;
+;; Use:
+;;   (siraben-have-p "rust-analyzer")            ; cached boolean
+;;   (siraben-when-program "clang-format" ...)   ; eval body conditionally
+;;   (siraben-eglot-ensure-if-server-available)  ; safe LSP hook
+;;
+;; The cache is invalidated by `siraben-capabilities-refresh'.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defvar siraben-capabilities--cache (make-hash-table :test 'equal)
+  "Memoization table for `siraben-have-p'.")
+
+(defun siraben-capabilities-refresh ()
+  "Forget every cached executable lookup."
+  (interactive)
+  (clrhash siraben-capabilities--cache))
+
+(defun siraben-have-p (program)
+  "Return non-nil when PROGRAM is on `exec-path' (cached).
+PROGRAM may be a string or a list of alternatives; for a list the
+first installed one is returned."
+  (cond
+   ((null program) nil)
+   ((listp program)
+    (cl-some #'siraben-have-p program))
+   (t
+    (let ((cached (gethash program siraben-capabilities--cache 'unset)))
+      (if (eq cached 'unset)
+          (let ((found (executable-find program)))
+            (puthash program found siraben-capabilities--cache)
+            found)
+        cached)))))
+
+(defmacro siraben-when-program (program &rest body)
+  "Evaluate BODY only if PROGRAM is installed.
+PROGRAM is a string (or list of alternatives) accepted by
+`siraben-have-p'.  Returns the body's value or nil."
+  (declare (indent 1))
+  `(when (siraben-have-p ,program)
+     ,@body))
+
+;; ---------------------------------------------------------------------------
+;; eglot helpers
+
+(defvar siraben-lsp-servers
+  '((python-mode      . ("basedpyright-langserver" "pyright-langserver"
+                         "pylsp" "jedi-language-server"))
+    (python-ts-mode   . ("basedpyright-langserver" "pyright-langserver"
+                         "pylsp" "jedi-language-server"))
+    (rustic-mode      . ("rust-analyzer"))
+    (rust-mode        . ("rust-analyzer"))
+    (rust-ts-mode     . ("rust-analyzer"))
+    (typescript-mode  . ("typescript-language-server" "tsserver"))
+    (typescript-ts-mode . ("typescript-language-server" "tsserver"))
+    (kotlin-mode      . ("kotlin-language-server"))
+    (c-mode           . ("clangd" "ccls"))
+    (c++-mode         . ("clangd" "ccls"))
+    (c-ts-mode        . ("clangd" "ccls"))
+    (c++-ts-mode      . ("clangd" "ccls"))
+    (nix-mode         . ("nil" "nixd" "rnix-lsp"))
+    (haskell-mode     . ("haskell-language-server-wrapper"
+                         "haskell-language-server")))
+  "Alist of (MAJOR-MODE . LIST-OF-LSP-BINARIES) used by
+`siraben-eglot-ensure-if-server-available'.  The first installed
+binary in the list wins.")
+
+(defun siraben-eglot-ensure-if-server-available ()
+  "Like `eglot-ensure', but no-op if no known LSP server is installed.
+Consult `siraben-lsp-servers' for the binaries to look for.  This is
+meant to be used in `MODE-hook' clauses where blindly calling
+`eglot-ensure' on a system without the server only pollutes the echo
+area with \"Searching for program: No such file or directory\" messages."
+  (let* ((servers (cdr (assq major-mode siraben-lsp-servers)))
+         (chosen  (siraben-have-p servers)))
+    (when chosen
+      (require 'eglot)
+      (eglot-ensure))))
+
+;; ---------------------------------------------------------------------------
+;; Reporting
+
+(defun siraben-capabilities-report ()
+  "Display a buffer listing which optional tools are detected.
+Useful to see at a glance what is enabled on the current host."
+  (interactive)
+  (let ((buf (get-buffer-create "*siraben-capabilities*"))
+        (tools '(;; LSP servers
+                 "basedpyright-langserver" "pyright-langserver" "pylsp"
+                 "rust-analyzer"
+                 "typescript-language-server" "tsserver"
+                 "clangd" "ccls"
+                 "nil" "nixd"
+                 "haskell-language-server-wrapper"
+                 "kotlin-language-server"
+                 ;; Formatters / linters
+                 "clang-format" "rustfmt" "black" "ruff"
+                 "prettier" "nixpkgs-fmt" "ormolu" "stylish-haskell"
+                 ;; Multiplexers
+                 "rass"
+                 ;; Build / package tools
+                 "cargo" "rustc" "cabal" "stack" "ghc" "nix" "make"
+                 ;; Shells
+                 "zsh" "bash" "fish" "pwsh"
+                 ;; Lisps
+                 "sbcl" "ccl" "clisp"
+                 ;; Misc
+                 "git" "rg" "direnv")))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (format ";; Capabilities on %s (%s)\n\n"
+                        system-type
+                        (or (and (boundp 'system-configuration)
+                                 system-configuration)
+                            "?")))
+        (dolist (tool tools)
+          (insert (format "  %-40s %s\n"
+                          tool
+                          (or (siraben-have-p tool) "—"))))
+        (special-mode)))
+    (pop-to-buffer buf)))
+
+(provide 'siraben-capabilities)
+;;; siraben-capabilities.el ends here

--- a/emacs/.emacs.d/modules/siraben-fonts.el
+++ b/emacs/.emacs.d/modules/siraben-fonts.el
@@ -24,11 +24,30 @@
 
 ;;; Code:
 
-(defvar siraben-default-font "DejaVu Sans Mono" "The default font type.")
+(defvar siraben-font-candidates
+  '("DejaVu Sans Mono" "Hack" "Source Code Pro" "Fira Code"
+    "Cascadia Mono" "Cascadia Code" "Consolas" "Menlo"
+    "Liberation Mono" "Courier New" "Monospace")
+  "Ordered list of monospace fonts to try. First installed wins.")
+
+(defun siraben--first-available-font (candidates)
+  "Return the first name in CANDIDATES that is installed, or nil."
+  (and (display-graphic-p)
+       (seq-find (lambda (name)
+                   (find-font (font-spec :name name)))
+                 candidates)))
+
+(defvar siraben-default-font
+  (or (siraben--first-available-font siraben-font-candidates)
+      "DejaVu Sans Mono")
+  "The default font type.  Auto-detected from `siraben-font-candidates'.")
+
 (defvar siraben-default-font-size
   (cond
    ((eq system-type 'darwin) 13)
-   ((eq system-type 'gnu/linux) 10))
+   ((eq system-type 'gnu/linux) 10)
+   ((eq system-type 'windows-nt) 10)
+   (t 10))
   "The default font size.")
 
 (defvar siraben-font-change-increment 1.1
@@ -42,10 +61,19 @@
 (defun siraben-set-font-size ()
   "Set the font to `siraben-default-font' at `siraben-current-font-size'.
 Set that for the current frame, and also make it the default for
-other, future frames."
-  (let ((font-code (siraben-font-code)))
-    (add-to-list 'default-frame-alist (cons 'font font-code))
-    (set-frame-font font-code)))
+other, future frames.  Silently no-ops in TTY frames or when the
+font isn't installed."
+  (when (and (display-graphic-p)
+             siraben-default-font
+             siraben-current-font-size
+             (find-font (font-spec :name siraben-default-font)))
+    (let ((font-code (siraben-font-code)))
+      (add-to-list 'default-frame-alist (cons 'font font-code))
+      (condition-case err
+          (set-frame-font font-code nil t)
+        (error
+         (message "siraben-set-font-size: could not set %s: %S"
+                  font-code err))))))
 
 (defun siraben-reset-font-size ()
   "Change font size back to `siraben-default-font-size'."

--- a/emacs/.emacs.d/modules/siraben-haskell.el
+++ b/emacs/.emacs.d/modules/siraben-haskell.el
@@ -58,11 +58,18 @@
       ("`isProperSubsetOf`" . ?⊂)
       ("undefined"          . ?⊥)))
 
+  (require 'siraben-capabilities)
   (defun siraben--haskell-mode-setup ()
     (subword-mode             t)
-    (interactive-haskell-mode t)
-    (diminish 'interactive-haskell-mode)
-    (flycheck-haskell-setup)
+    ;; `interactive-haskell-mode' shells out to ghci/cabal/stack; only
+    ;; turn it on when one of them is installed.
+    (when (siraben-have-p '("ghci" "cabal" "stack" "ghc"))
+      (interactive-haskell-mode t)
+      (when (fboundp 'diminish)
+        (diminish 'interactive-haskell-mode)))
+    (when (and (fboundp 'flycheck-haskell-setup)
+               (siraben-have-p '("ghc" "cabal" "stack")))
+      (flycheck-haskell-setup))
     (setq-local prettify-symbols-alist haskell-prettify-symbols-alist)
     (prettify-symbols-mode 1)
     (haskell-indentation-mode t))

--- a/emacs/.emacs.d/modules/siraben-packages.el
+++ b/emacs/.emacs.d/modules/siraben-packages.el
@@ -187,12 +187,30 @@
   :demand
   :config (load-theme 'sanityinc-tomorrow-night t))
 
+(defun siraben--font-has-char-p (font char)
+  "Return non-nil if FONT can render CHAR."
+  (condition-case nil
+      (let ((glyphs (font-get-glyphs font 0 1 (string char))))
+        (and glyphs (aref glyphs 0)))
+    (error nil)))
+
+(defun siraben--has-powerline-glyphs-p ()
+  "Return non-nil if the default font can render Powerline glyph U+E0B0."
+  (when (display-graphic-p)
+    (let ((font (face-attribute 'default :font nil t)))
+      (and (fontp font)
+           (siraben--font-has-char-p font #xE0B0)))))
+
 (use-package spaceline
   :hook (after-init . siraben--setup-spaceline)
   :config
   (defun siraben--setup-spaceline ()
-    "Configure spaceline modeline."
-    (setq powerline-default-separator 'utf-8)
+    "Configure spaceline modeline.
+Uses fancy `utf-8' powerline separators when the default font supplies
+the required Private Use Area glyphs (Powerline / Nerd Fonts), otherwise
+falls back to plain ASCII separators so the mode-line stays readable."
+    (setq powerline-default-separator
+          (if (siraben--has-powerline-glyphs-p) 'utf-8 'bar))
     (spaceline-emacs-theme)))
 
 (use-package webpaste
@@ -234,7 +252,12 @@
 (use-package inheritenv)
 
 (use-package envrc
-  :hook (after-init . envrc-global-mode)
+  ;; Only enable envrc-global-mode when direnv is actually installed;
+  ;; otherwise every buffer would log a warning about a missing binary.
+  :hook (after-init . (lambda ()
+                        (require 'siraben-capabilities)
+                        (when (siraben-have-p "direnv")
+                          (envrc-global-mode))))
   :config
   ;; Ensure eglot inherits buffer-local env vars set by envrc,
   ;; and restart the LSP server when the environment changes.
@@ -332,13 +355,16 @@
   :bind (:map eglot-mode-map
               ("M-." . xref-find-definitions)
               ("M-," . xref-go-back))
-  :hook ((python-mode . eglot-ensure)
-         (rustic-mode . eglot-ensure)
-         (typescript-mode . eglot-ensure)
-         (kotlin-mode . eglot-ensure)
-         (c-mode . eglot-ensure)
-         (c++-mode . eglot-ensure)
-         (nix-mode . eglot-ensure)))
+  ;; Capability-driven: each hook only starts eglot when a known LSP
+  ;; server binary for that language is installed.  See
+  ;; `siraben-lsp-servers' / `siraben-eglot-ensure-if-server-available'.
+  :hook ((python-mode . siraben-eglot-ensure-if-server-available)
+         (rustic-mode . siraben-eglot-ensure-if-server-available)
+         (typescript-mode . siraben-eglot-ensure-if-server-available)
+         (kotlin-mode . siraben-eglot-ensure-if-server-available)
+         (c-mode . siraben-eglot-ensure-if-server-available)
+         (c++-mode . siraben-eglot-ensure-if-server-available)
+         (nix-mode . siraben-eglot-ensure-if-server-available)))
 
 (provide 'siraben-packages)
 ;;; siraben-packages.el ends here

--- a/emacs/.emacs.d/modules/siraben-python.el
+++ b/emacs/.emacs.d/modules/siraben-python.el
@@ -25,11 +25,25 @@
 
 (use-package pyvenv)
 
-;; Use basedpyright (type checking) + ruff (linting/formatting) via rass multiplexer.
+;; Capability-driven Python LSP setup.
+;;
+;; Preferred stack: basedpyright (type checking) + ruff (lint / format)
+;; multiplexed by `rass'.  If `rass' is missing we fall back to plain
+;; basedpyright; if that is also missing we leave the defaults alone and
+;; let `siraben-eglot-ensure-if-server-available' decide whether eglot
+;; should fire at all.
 (with-eval-after-load 'eglot
-  (add-to-list 'eglot-server-programs
-               '((python-mode python-ts-mode) .
-                 ("rass" "--" "basedpyright-langserver" "--stdio" "--" "ruff" "server"))))
+  (require 'siraben-capabilities)
+  (cond
+   ((and (siraben-have-p "rass")
+         (siraben-have-p "basedpyright-langserver"))
+    (add-to-list 'eglot-server-programs
+                 '((python-mode python-ts-mode) .
+                   ("rass" "--" "basedpyright-langserver" "--stdio" "--" "ruff" "server"))))
+   ((siraben-have-p "basedpyright-langserver")
+    (add-to-list 'eglot-server-programs
+                 '((python-mode python-ts-mode) .
+                   ("basedpyright-langserver" "--stdio"))))))
 
 (provide 'siraben-python)
 ;;; siraben-python.el ends here

--- a/emacs/.emacs.d/modules/siraben-rust.el
+++ b/emacs/.emacs.d/modules/siraben-rust.el
@@ -26,8 +26,11 @@
 (use-package rustic
   :mode ("\\.rs\\'" . rustic-mode)
   :config
+  (require 'siraben-capabilities)
   (setq rustic-lsp-client 'eglot)
-  (setq rust-format-on-save t)
+  ;; Only auto-format on save when rustfmt is actually installed; otherwise
+  ;; every save would error out on Windows / minimal systems.
+  (setq rust-format-on-save (and (siraben-have-p "rustfmt") t))
   (defun siraben--rust-mode-setup ()
     "Configure Rust mode settings."
     (flycheck-rust-setup)

--- a/emacs/.emacs.d/modules/siraben-ui.el
+++ b/emacs/.emacs.d/modules/siraben-ui.el
@@ -47,8 +47,24 @@
 (setq use-short-answers t)
 
 ;; Extra mode line modes.
+(defun siraben--battery-available-p ()
+  "Return non-nil if this system has a real, queryable battery.
+Guards against `fancy-battery-mode' crashing on desktops/VMs where the
+platform battery driver returns \"N/A\" for all fields (notably Windows
+VMs and physical desktops)."
+  (require 'battery)
+  (and battery-status-function
+       (let ((data (ignore-errors (funcall battery-status-function))))
+         (and data
+              (let ((pct (cdr (assq ?p data))))
+                (and (stringp pct)
+                     (not (member pct '("" "N/A")))
+                     (ignore-errors (> (string-to-number pct) 0))))))))
+
 (use-package fancy-battery
-  :hook (after-init . fancy-battery-mode)
+  :hook (after-init . (lambda ()
+                        (when (siraben--battery-available-p)
+                          (fancy-battery-mode))))
   :config
   (setq fancy-battery-show-percentage t))
 


### PR DESCRIPTION
## Summary
- add an Emacs capabilities module for cached executable detection and safe Eglot startup
- gate optional formatters, LSP servers, envrc, Haskell tooling, Rust formatting, and battery UI on host capabilities
- make fonts and powerline separators fall back more gracefully on Windows/minimal hosts

## Notes
- ported from the Windows dotfiles diff in C:\Users\siraben\dotfiles
- excluded generated emacs/.emacs.d/straight/links output