### PR TITLE
emacs: normalize file headers and commentary

### DIFF
--- a/emacs/.emacs.d/early-init.el
+++ b/emacs/.emacs.d/early-init.el
@@ -1,1 +1,27 @@
+;;; early-init.el --- Configure Emacs before package and frame startup
+
+;;; License:
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Keep package.el from loading packages before init.el bootstraps the
+;; straight.el/use-package setup.
+
+;;; Code:
+
 (setq package-enable-at-startup nil)
+
+;;; early-init.el ends here

--- a/emacs/.emacs.d/modules/siraben-agda.el
+++ b/emacs/.emacs.d/modules/siraben-agda.el
@@ -1,4 +1,4 @@
-;;; siraben-agda.el --- configures Emacs for Agda development
+;;; siraben-agda.el --- Configure Emacs for Agda development
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify
@@ -15,6 +15,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Register Agda files and customize Agda mode faces when agda2-mode is
+;; available.
 
 ;;; Code:
 (add-to-list 'auto-mode-alist
@@ -56,4 +59,5 @@
      `(agda2-highlight-incomplete-pattern-face ((t (:background ,orange :foreground ,base03))))
      `(agda2-highlight-typechecks-face ((t (:background ,cyan :foreground ,base03)))))))
 
+(provide 'siraben-agda)
 ;;; siraben-agda.el ends here

--- a/emacs/.emacs.d/modules/siraben-assembly.el
+++ b/emacs/.emacs.d/modules/siraben-assembly.el
@@ -1,4 +1,4 @@
-;;; siraben-assembly.el --- Specific modes and packages for assembly code.
+;;; siraben-assembly.el --- Configure assembly editing helpers
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify
@@ -15,6 +15,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Tune asm-mode indentation and local editing modes for assembly files.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-c.el
+++ b/emacs/.emacs.d/modules/siraben-c.el
@@ -1,4 +1,4 @@
-;;; siraben-c.el --- configures Emacs for C development
+;;; siraben-c.el --- Configure Emacs for C and C++ development
 
 ;;; License:
 

--- a/emacs/.emacs.d/modules/siraben-cool.el
+++ b/emacs/.emacs.d/modules/siraben-cool.el
@@ -1,7 +1,33 @@
+;;; siraben-cool.el --- Major mode skeleton for Cool source files
+
+;;; License:
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Define a minimal major mode for the Cool language.
+
+;;; Code:
+
 (defun cool-mode ()
   (interactive)
   (kill-all-local-variables)
-  (setq mode-name  		"Cool")
-  (setq major-mode 		'cool-mode)
+  (setq mode-name "Cool")
+  (setq major-mode 'cool-mode)
   (electric-pair-mode t)
   (run-hooks 'cool-mode-hook))
+
+(provide 'siraben-cool)
+;;; siraben-cool.el ends here

--- a/emacs/.emacs.d/modules/siraben-core.el
+++ b/emacs/.emacs.d/modules/siraben-core.el
@@ -1,4 +1,4 @@
-;;; siraben-core.el --- This file contains the core functions I wrote.
+;;; siraben-core.el --- Core helper functions and command defaults
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify
@@ -15,6 +15,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Shared interactive helpers used by the rest of the Emacs configuration.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-editor.el
+++ b/emacs/.emacs.d/modules/siraben-editor.el
@@ -1,4 +1,4 @@
-;;; siraben-editor.el --- make Emacs a great editor.
+;;; siraben-editor.el --- Configure general editing behavior
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify
@@ -15,6 +15,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Enable global editing modes and defaults that apply outside any one
+;; programming language.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-fonts.el
+++ b/emacs/.emacs.d/modules/siraben-fonts.el
@@ -1,10 +1,10 @@
-;;; siraben-fonts.el --- Setup fonts
+;;; siraben-fonts.el --- Configure default fonts and resizing commands
 
 ;;; Commentary:
 
-;; This file sets up the use of the Hack font and various functions
-;; that allow fonts to be resized.  The font settings were inspired by
-;; hrs's dotfiles repository at
+;; Set the default monospace font and provide interactive commands for
+;; increasing, decreasing, and resetting frame font size.  The font settings
+;; were inspired by hrs's dotfiles repository at
 ;; `https://github.com/hrs/dotfiles/blob/master/emacs/.emacs.d/configuration.org'
 
 ;;; License:

--- a/emacs/.emacs.d/modules/siraben-forth.el
+++ b/emacs/.emacs.d/modules/siraben-forth.el
@@ -1,4 +1,4 @@
-;;; siraben-forth.el --- Specific modes and packages for Forth code.
+;;; siraben-forth.el --- Configure Forth editing support
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify
@@ -15,6 +15,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Install and configure forth-mode.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-haskell.el
+++ b/emacs/.emacs.d/modules/siraben-haskell.el
@@ -1,4 +1,4 @@
-;;; siraben-haskell.el -- Haskell programming customizations.
+;;; siraben-haskell.el --- Haskell programming customizations
 
 ;;; License:
 

--- a/emacs/.emacs.d/modules/siraben-keybindings.el
+++ b/emacs/.emacs.d/modules/siraben-keybindings.el
@@ -1,4 +1,4 @@
-;;; siraben-keybindings.el -- Customize keybindings
+;;; siraben-keybindings.el --- Customize global keybindings
 
 ;;; License:
 
@@ -15,12 +15,10 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;; This file sets up global keybindings. These keybindings are those
-;; that weren't set up in `use-package' declarations.
-
 ;;; Commentary:
 
-;; Customization of global keybindings.
+;; Set global keybindings that are not owned by a package-specific
+;; `use-package' declaration.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-lisp.el
+++ b/emacs/.emacs.d/modules/siraben-lisp.el
@@ -1,4 +1,4 @@
-;;; siraben-lisp.el --- Specific modes and packages for Lisp code.
+;;; siraben-lisp.el --- Configure Lisp-family editing support
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify
@@ -15,6 +15,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Enable structural editing, delimiter highlighting, and related packages for
+;; Lisp-family modes.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-macos.el
+++ b/emacs/.emacs.d/modules/siraben-macos.el
@@ -1,4 +1,4 @@
-;;; siraben-macos.el --- This files runs when the host OS is macOS.
+;;; siraben-macos.el --- macOS-specific Emacs configuration
 
 ;;; License:
 

--- a/emacs/.emacs.d/modules/siraben-mdm.el
+++ b/emacs/.emacs.d/modules/siraben-mdm.el
@@ -1,4 +1,4 @@
-;;; siraben-mdm.el -- emulating The Most Dangerous Writing App
+;;; siraben-mdm.el --- Emulate The Most Dangerous Writing App
 
 ;;; License:
 
@@ -15,14 +15,11 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;; This mode was written from scratch by me after being inspired by
-;; The Most Dangerous Writing App which can be found at
-;; `https://www.themostdangerouswritingapp.com/'
-
 ;;; Commentary:
-;; There's no guarantee that this code is up to style.  It's very
-;; hacky as it is, but it works good enough for my purposes.  I'll
-;; read the Emacs Lisp manual later.
+
+;; Provide `most-dangerous-mode', a writing timer inspired by The Most
+;; Dangerous Writing App:
+;; `https://www.themostdangerouswritingapp.com/'
 
 ;;; Code:
 (defvar siraben-mdt-grace 5)

--- a/emacs/.emacs.d/modules/siraben-ocaml.el
+++ b/emacs/.emacs.d/modules/siraben-ocaml.el
@@ -1,4 +1,4 @@
-;;; siraben-ocaml.el --- configures Emacs for OCaml development
+;;; siraben-ocaml.el --- Configure Emacs for OCaml development
 
 ;;; License:
 
@@ -16,6 +16,8 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Configure tuareg and OCaml-specific Flycheck integration.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-packages.el
+++ b/emacs/.emacs.d/modules/siraben-packages.el
@@ -1,4 +1,4 @@
-;;; siraben-packages.el --- Set up MELPA packages
+;;; siraben-packages.el --- Bootstrap and configure Emacs packages
 
 ;;; License:
 
@@ -17,8 +17,8 @@
 
 ;;; Commentary:
 
-;; This file sets up `use-package', which handles the installation of
-;; most packages.
+;; Bootstrap straight.el and use-package, then declare package-level
+;; configuration shared across the Emacs setup.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-programming.el
+++ b/emacs/.emacs.d/modules/siraben-programming.el
@@ -1,4 +1,4 @@
-;;; siraben-programming.el -- siraben's programming configuration
+;;; siraben-programming.el --- Load programming language configuration
 
 ;;; License:
 
@@ -17,8 +17,7 @@
 
 ;;; Commentary:
 
-;; This file makes managing the different programming modes that
-;; need to be loaded easier.
+;; Set shared programming-mode defaults and load language-specific modules.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-sml.el
+++ b/emacs/.emacs.d/modules/siraben-sml.el
@@ -1,4 +1,4 @@
-;;; siraben-sml.el --- Specific modes and packages for Standard ML code.
+;;; siraben-sml.el --- Configure Standard ML editing support
 
 ;;; License:
 ;; This program is free software: you can redistribute it and/or modify

--- a/emacs/.emacs.d/modules/siraben-tramp.el
+++ b/emacs/.emacs.d/modules/siraben-tramp.el
@@ -1,4 +1,4 @@
-;;; siraben-tramp.el -- siraben's TRAMP configuration
+;;; siraben-tramp.el --- TRAMP and remote terminal helpers
 
 ;;; License:
 
@@ -17,8 +17,8 @@
 
 ;;; Commentary:
 
-;; This file makes managing the different programming modes that
-;; need to be loaded easier.
+;; Configure TRAMP defaults and provide a helper for opening an ansi-term in a
+;; local or remote path.
 
 ;;; Code:
 

--- a/emacs/.emacs.d/modules/siraben-ui.el
+++ b/emacs/.emacs.d/modules/siraben-ui.el
@@ -1,4 +1,6 @@
-;;; siraben-ui.el -- configure Emacs' visual appearance.
+;;; siraben-ui.el --- Configure Emacs visual appearance
+
+;;; License:
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -14,8 +16,9 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; This file configures the visual appearance of Emacs, loads
-;; my favorite theme, and adds a smart mode line.
+
+;; Configure global visual defaults, scrolling behavior, modeline helpers, and
+;; display-related quality-of-life settings.
 
 ;;; Code:
 


### PR DESCRIPTION
## Summary
- add missing header/commentary/code/footer structure to early-init.el and siraben-cool.el
- normalize Emacs Lisp package header delimiters and stale descriptions
- fill empty Commentary sections and add missing provide forms for siraben-agda/siraben-cool

## Audit
- checked Emacs Lisp files under emacs/.emacs.d, excluding generated straight directories and straight/versions/default.el
- verified no missing/malformed headers, missing Commentary/Code markers, empty Commentary blocks, missing siraben-* provide forms, or whitespace errors remain

## Testing
- git diff --check
- custom header audit script