### PR TITLE
emacs: only add undo-tree .gz advice when gzip is available

### DIFF
--- a/emacs/.emacs.d/modules/siraben-packages.el
+++ b/emacs/.emacs.d/modules/siraben-packages.el
@@ -123,9 +123,12 @@
   :commands (global-undo-tree-mode)
   :hook ((after-init . global-undo-tree-mode))
   :config
-  ;; Compress undo-tree history files
-  (advice-add 'undo-tree-make-history-save-file-name :filter-return
-              (lambda (filename) (concat filename ".gz")))
+  ;; Compress undo-tree history files when gzip is available.  Emacs uses the
+  ;; external gzip program for .gz files, which is not installed by default
+  ;; on Windows.
+  (when (executable-find "gzip")
+    (advice-add 'undo-tree-make-history-save-file-name :filter-return
+                (lambda (filename) (concat filename ".gz"))))
 
   (setq undo-tree-history-directory-alist
         `((".*" . ,temporary-file-directory))


### PR DESCRIPTION
Emacs shells out to the external **gzip** program to write `.gz` files, which isn't installed by default on Windows. The unconditional `undo-tree-make-history-save-file-name` advice appended `.gz` to every undo-history filename, so on a gzip-less machine undo-tree history saves would fail.

Guard the advice on `(executable-find "gzip")` — history compression still happens where gzip is present, and undo history saves uncompressed elsewhere.

Ported from the corresponding unstaged change on my Windows box.