### PR TITLE
Harden server-arm operational safeguards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.elc
 .DS_Store
+.env
 nixos/hardware-configuration.nix
 result
 

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,10 @@
           modules = [
             allInputs.agenix.nixosModules.default
             ./server-arm/configuration.nix
+            {
+              # Surface the deployed Git revision in `nixos-version --json`.
+              system.configurationRevision = self.rev or self.dirtyRev or null;
+            }
           ];
         };
       };

--- a/server-arm/README.md
+++ b/server-arm/README.md
@@ -1,0 +1,11 @@
+# server-arm operations
+
+`server-arm` is deployed from this flake. Always name the flake output:
+
+```bash
+sudo nixos-rebuild test --flake ~/dotfiles#server-arm
+sudo nixos-rebuild switch --flake ~/dotfiles#server-arm
+```
+
+Do not run a bare `nixos-rebuild switch` on the host. `/etc/nixos` is not the
+source of truth and may be stale.

--- a/server-arm/configuration.nix
+++ b/server-arm/configuration.nix
@@ -172,10 +172,12 @@ in
     interval = "Sat *-*-* 04:00:00";
   };
 
-  # Bump journal retention now that root has headroom (was capped ~460M)
+  # Root is a small OCI volume; keep journald from consuming most of it.
+  # Durable application data lives on ZFS under /home instead.
   services.journald.extraConfig = ''
-    SystemMaxUse=2G
-    MaxRetentionSec=2month
+    SystemMaxUse=512M
+    SystemKeepFree=1G
+    MaxRetentionSec=14day
   '';
   systemd.services."nextcloud-setup" = {
     requires = [ "postgresql.service" ];

--- a/server-arm/configuration.nix
+++ b/server-arm/configuration.nix
@@ -84,6 +84,7 @@ in
   programs.mosh.enable = true;
   programs.zsh.enable = true;
   services.tailscale.enable = true;
+  networking.firewall.trustedInterfaces = [ "tailscale0" ];
   services.eternal-terminal.enable = true;
 
   # User


### PR DESCRIPTION
## What changed

- ignore local `.env` files so plaintext tokens are not accidentally staged
- cap persistent journald usage at 512 MiB, reserve 1 GiB of root space, and retain 14 days
- record the deployed Git revision in NixOS generation metadata
- document the required `~/dotfiles#server-arm` deployment command and warn against the stale `/etc/nixos` configuration
- explicitly trust `tailscale0` so firewall reloads preserve the administrative overlay path

## Why

The live host has a small root filesystem, while journald currently consumes about 2.1 GiB under a 2 GiB limit. The public dotfiles checkout also had a local plaintext `.env` staged, and `/etc/nixos` is not the deployed source of truth.

A live NixOS firewall reload also interrupted overlay SSH because the overlay interface was enabled but not declared trusted. Declaring it in the firewall makes remote administration stable across configuration switches.

This PR does not contain the staged token, any host-local encrypted secret changes, or any live credential values.

## Validation

- `git diff --check`
- `.env` confirmed ignored with `git check-ignore`
- `nix eval --raw .#nixosConfigurations.server-arm.config.system.build.toplevel.drvPath`
- evaluated journald settings and configuration revision
- `nix eval --json .#nixosConfigurations.server-arm.config.networking.firewall.trustedInterfaces` → `["tailscale0","lo"]`

A whole-flake `nix flake check --no-build` is currently blocked by an unrelated existing issue: unstable Nixpkgs has dropped `x86_64-darwin`, but the flake still declares an x86_64 Darwin Home Manager output.