### PR TITLE
beelink: restore Kitty and Bangkok timezone

### DIFF
--- a/beelink/configuration.nix
+++ b/beelink/configuration.nix
@@ -302,6 +302,7 @@ in
 
     # KDE / Plasma tools
     kdePackages.konsole
+    kitty
     kdePackages.dolphin
     kdePackages.spectacle
     kdePackages.kcalc

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,12 @@
             {
               home-manager.useUserPackages = true;
               home-manager.users.${username} = import ./home-manager/.config/nixpkgs/home.nix;
-              home-manager.extraSpecialArgs = { inherit username; inputs = allInputs; profile = "headless"; };
+              home-manager.extraSpecialArgs = {
+                inherit username;
+                inputs = allInputs;
+                profile = "headless";
+                timeZone = "Asia/Bangkok";
+              };
             }
           ];
         };

--- a/home-manager/.config/nixpkgs/base.nix
+++ b/home-manager/.config/nixpkgs/base.nix
@@ -1,4 +1,4 @@
-{ config, lib, currentSystem, profile, inputs, ... }:
+{ config, lib, currentSystem, profile, inputs, timeZone ? "America/Los_Angeles", ... }:
 
 let
   inherit (lib.systems.elaborate { system = currentSystem; }) isLinux isDarwin;
@@ -48,7 +48,7 @@ lib.recursiveUpdate (rec {
 
   home.sessionVariables = {
     EDITOR = "emacsclient";
-    TZ = "America/Los_Angeles";
+    TZ = timeZone;
   } // (lib.optionalAttrs isDarwin {
     HOMEBREW_NO_AUTO_UPDATE = 1;
     HOMEBREW_NO_ANALYTICS = 1;


### PR DESCRIPTION
Restores Kitty to the Beelink NixOS system packages and makes the Home Manager timezone configurable, with Asia/Bangkok selected for Beelink.

Validated with targeted Nix evaluations and a live `nixos-rebuild switch` on Beelink. Kitty 0.46.2 is active from `/run/current-system/sw`, the user-profile imperative install is absent, and the Plasma taskbar icons render correctly. Forgejo, Caddy, PostgreSQL, and both Gitea runners are active after the switch.

Note: the repository-wide flake check remains blocked by the existing `x86_64-darwin` output, which current nixpkgs no longer supports.