### PR TITLE
home-manager: disable Context Mode by default

### DIFF
--- a/home-manager/.config/nixpkgs/pi-home.nix
+++ b/home-manager/.config/nixpkgs/pi-home.nix
@@ -34,7 +34,10 @@ in
           }
           "${pkgs.pi-codex-goal}/lib/node_modules/pi-codex-goal"
           "${pkgs.pi-web-access}/lib/node_modules/pi-web-access"
-          "${pkgs.context-mode}/lib/node_modules/context-mode"
+          {
+            source = "${pkgs.context-mode}/lib/node_modules/context-mode";
+            autoload = false;
+          }
         ];
       };
     };


### PR DESCRIPTION
## Summary

- keep Context Mode packaged through Nix
- set its Pi package entry to `autoload: false`
- prevent the Context Mode extension, internal MCP bridge, and `ctx_*` tools from loading by default

## Verification

- `nix build --no-link .#homeConfigurations."siraben@x86_64-linux-full".activationPackage`
- rendered settings contain the Context Mode source with `autoload: false`