### PR TITLE
home-manager: default Pi to GPT-5.6 Sol

### DIFF
--- a/home-manager/.config/nixpkgs/pi-home.nix
+++ b/home-manager/.config/nixpkgs/pi-home.nix
@@ -16,12 +16,16 @@ in
 
   home.file = {
     # Pi mutates settings at runtime, so keep the changelog marker aligned with
-    # the packaged version. Provider/model selection intentionally falls back
-    # to Pi rather than pinning the removed OpenRouter ox-alpha model.
+    # the packaged version and pin startup model selection declaratively.
     ".pi/agent/settings.json" = {
       force = true;
       text = builtins.toJSON {
+        defaultModel = "gpt-5.6-sol";
+        defaultProvider = "openai-codex";
         defaultThinkingLevel = "high";
+        modelThinkingLevels = {
+          "openai-codex/gpt-5.6-sol" = "high";
+        };
         enableAnalytics = false;
         enableInstallTelemetry = false;
         lastChangelogVersion = pkgs.pi-coding-agent.version;


### PR DESCRIPTION
## Summary

- set Pi startup provider to `openai-codex`
- set the startup model to `gpt-5.6-sol`
- keep `high` as the global thinking default
- explicitly pin `openai-codex/gpt-5.6-sol` to high thinking

## Verification

- `nix build --no-link .#homeConfigurations."siraben@x86_64-linux-full".activationPackage`
- rendered settings contain the expected provider, model, and thinking level
- Pi 0.84.4 model catalog resolves `openai-codex/gpt-5.6-sol` with reasoning support